### PR TITLE
fix prompt-toolkit mismatch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,8 +32,7 @@ RUN ln /dev/null /dev/raw1394
 
 # Additional updates to pip
 RUN pip install --upgrade pip && \
-    pip install ptpython && \
-    pip install 'prompt-toolkit==1.0.15' --force-reinstall && \
+    pip install ptpython==0.41 && \
     mkdir -p /data/outputs /data/inputs \
              data/outputs data/inputs
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,7 @@ RUN ln /dev/null /dev/raw1394
 # Additional updates to pip
 RUN pip install --upgrade pip && \
     pip install ptpython && \
+    pip install 'prompt-toolkit==1.0.15' --force-reinstall && \
     mkdir -p /data/outputs /data/inputs \
              data/outputs data/inputs
 


### PR DESCRIPTION
When trying to build this test branch I would get:

from prompt_toolkit.shortcuts import create_prompt_application, create_eventloop, create_prompt_layout, create_output ImportError: cannot import name create_prompt_application

When trying this solution:
`sudo pip install 'prompt-toolkit==1.0.15'
`
From:
https://github.com/jupyter/jupyter_console/issues/158

The error seems to go away. I don't know how to verify multi model selection is working, but the error is gone. 